### PR TITLE
show a placeholder in case the item doesn't have any image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

show a placeholder in case the item doesn't have any image
## Type of change

Please delete options that are not relevant.

- [X] Bug fix
- [ ] New feature
- [ ] A documentation update
- [ ] Refactoring
